### PR TITLE
Build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ option(FORCE_PATCH  "Specify -f when patching (deprecated)" FALSE)
 option(ON_DEMAND    "Build targets on demand" FALSE)
 option(OVERRIDE_PKGS "Use own versions of subpackages" TRUE)
 option(PATCH        "Patch source after downloading" TRUE)
-option(RECENT_GRPC  "Use more recent version of gRPC" FALSE)
+option(RECENT_PKGS  "Use newer versions of packages" FALSE)
 option(USE_LDCONFIG "Use ldconfig when installing" FALSE)
 
 # Note: USE_SUDO should be DISABLED by default.

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -10,7 +10,7 @@ set(GRPC_GIT_URL        https://github.com/google/grpc.git)
 set(PROTOBUF_GIT_URL    https://github.com/google/protobuf.git)
 set(ZLIB_GIT_URL        https://github.com/madler/zlib)
 
-if(RECENT_GRPC)
+if(RECENT_PKGS)
   set(ABSEIL_GIT_TAG    c2435f8342c2d0ed8101cb43adfd605fdc52dca2) # 20230125.3
   set(CARES_GIT_TAG     6360e96b5cf8e5980c887ce58ef727e53d77243a) # v1.19.1
   set(GRPC_GIT_TAG      6e85620c7e258df79666a4743f862f2f82701c2d) # v1.56.0

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+unset(_absl_provider)
 unset(_build_shared_libs)
 unset(_source_subdir)
 
@@ -11,16 +12,23 @@ GetDownloadSpec(DOWNLOAD_PROTOBUF ${PROTOBUF_GIT_URL} ${PROTOBUF_GIT_TAG})
 
 # In older versions of protobuf, the primary CMakeLists.txt file
 # is in the cmake subdirectory.
-if(NOT RECENT_GRPC)
+if(NOT RECENT_PKGS)
   set(_source_subdir SOURCE_SUBDIR cmake)
 endif()
 
 # Protobuf v23.x generates unresolved external references to
 # ThreadSafeArena::ThreadCache _thread_cache if BUILD_SHARED_LIBS=ON.
-if(RECENT_GRPC)
+if(RECENT_PKGS)
   set(_build_shared_libs off)
 else()
   set(_build_shared_libs on)
+endif()
+
+# Protobuf v23.x bundles its own copy of Abseil.
+# We suppress it in favor of our own version or the
+# version bundles with gRPC.
+if(RECENT_PKGS)
+  set(_absl_provider -Dprotobuf_ABSL_PROVIDER=package)
 endif()
 
 ExternalProject_Add(protobuf
@@ -36,7 +44,7 @@ ExternalProject_Add(protobuf
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
     -DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}
     -DBUILD_SHARED_LIBS=${_build_shared_libs}
-    -Dprotobuf_ABSL_PROVIDER=package
+    ${_absl_provider}
     -Dprotobuf_BUILD_TESTS=off
   ${_source_subdir}
   INSTALL_COMMAND

--- a/scripts/recent-grpc.sh
+++ b/scripts/recent-grpc.sh
@@ -4,4 +4,4 @@
 cmake -B build \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=recent-deps \
-  -DRECENT_GRPC=YES
+  -DRECENT_PKGS=YES


### PR DESCRIPTION
- Rename RECENT_GRPC option to RECENT_PKGS. It updates more than just GRPC.

- Only specify the protobuf_ABSL_PROVIDER option when building newer versions of Protobuf.