### PR TITLE
Helper script maintenance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,13 @@ endif()
 # Configuration variables
 #-----------------------------------------------------------------------
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the build type." FORCE)
+endif()
+
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug;Release;RelWithDebInfo")
+
 if(NOT CMAKE_BUILD_TYPE STREQUAL "")
   set(cmake_BUILD_TYPE "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 endif()

--- a/scripts/make-cross-deps.sh
+++ b/scripts/make-cross-deps.sh
@@ -30,7 +30,6 @@ _SYSROOT=${SDKTARGETSYSROOT}
 # Default values #
 ##################
 
-_BLD_TYPE="Release"
 _BLD_DIR=build
 _CFG_ONLY=0
 _DRY_RUN=0
@@ -68,9 +67,8 @@ print_help() {
     echo ""
     echo "Configurations:"
     echo "  --debug              Debug configuration"
-    echo "  --minsize            MinSizeRel configuration"
     echo "  --reldeb             RelWithDebInfo configuration"
-    echo "  --release            Release configuration (default)"
+    echo "  --release            Release configuration"
     echo ""
     echo "Environment variables:"
     echo "  CMAKE_TOOLCHAIN_FILE - Default toolchain file"
@@ -86,7 +84,7 @@ print_help() {
 print_cmake_params() {
     echo ""
     [ -n "${_GENERATOR}" ] && echo "${_GENERATOR}"
-    echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
+    [ -n "${_BUILD_TYPE}" ] && echo "${_BUILD_TYPE:2}"
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
     echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
     [ -n "${_CXX_STD}" ] && echo "CXX_STANDARD=${_CXX_STD}"
@@ -112,7 +110,7 @@ config_build() {
     # shellcheck disable=SC2086
     cmake -S . -B "${_BLD_DIR}" \
         ${_GENERATOR} \
-        -DCMAKE_BUILD_TYPE="${_BLD_TYPE}" \
+        ${_BUILD_TYPE} \
         -DCMAKE_INSTALL_PREFIX="${_PREFIX}" \
         -DCMAKE_TOOLCHAIN_FILE="${_TOOLFILE}" \
         ${_CXX_STANDARD} \
@@ -132,7 +130,7 @@ SHORTOPTS=${SHORTOPTS}hn
 
 LONGOPTS=build:,hostdeps:,prefix:,toolchain:
 LONGOPTS=${LONGOPTS},cxx-std:,jobs:
-LONGOPTS=${LONGOPTS},debug,release,minsize,reldeb
+LONGOPTS=${LONGOPTS},debug,release,reldeb
 LONGOPTS=${LONGOPTS},config,dry-run,force,help,ninja
 LONGOPTS=${LONGOPTS},no-download,no-patch,sudo
 
@@ -156,16 +154,13 @@ while true ; do
         shift 2 ;;
     # Configurations
     --debug)
-        _BLD_TYPE="Debug"
-        shift ;;
-    --minsize)
-        _BLD_TYPE="MinSizeRel"
+        _BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug"
         shift ;;
     --reldeb)
-        _BLD_TYPE="RelWithDebInfo"
+        _BUILD_TYPE="-DCMAKE_BUILD_TYPE=RelWithDebInfo"
         shift ;;
     --release)
-        _BLD_TYPE="Release"
+        _BUILD_TYPE="-DCMAKE_BUILD_TYPE=Release"
         shift ;;
     # Options
     --config)

--- a/scripts/make-cross-deps.sh
+++ b/scripts/make-cross-deps.sh
@@ -10,6 +10,10 @@
 # Abort on error.
 set -e
 
+#################
+# Check sysroot #
+#################
+
 if [ -z "${SDKTARGETSYSROOT}" ]; then
     echo ""
     echo "-----------------------------------------------------"
@@ -27,8 +31,9 @@ _SYSROOT=${SDKTARGETSYSROOT}
 ##################
 
 _BLD_DIR=build
-_CFG_ONLY=false
-_DRY_RUN=false
+_CFG_ONLY=0
+_DRY_RUN=0
+_HOST_DIR=${HOST_INSTALL}
 _NJOBS=8
 _PREFIX=//opt/deps
 _TOOLFILE=${CMAKE_TOOLCHAIN_FILE}
@@ -48,19 +53,21 @@ print_help() {
     echo "  --toolchain=FILE -T  CMake toolchain file"
     echo ""
     echo "Options:"
-    echo "  --config             Only perform configuration step"
-    echo "  --cxx=VERSION        CXX_STANDARD to specify [${CXX_STD}]"
+    echo "  --config             Configure without building"
+    echo "  --cxx=STD            C++ standard to be used [${_CXX_STD}]"
     echo "  --dry-run        -n  Display cmake parameters and exit"
-    echo "  --force          -f  Specify -f when patching"
+    echo "  --force          -f  Specify -f when patching (deprecated)"
     echo "  --jobs=NJOBS     -j  Number of build threads [${_NJOBS}]"
     echo "  --no-download        Do not download repositories"
+    echo "  --no-patch           Do not patch source after downloading"
     echo "  --sudo               Use sudo when installing"
     echo ""
     echo "* '//' at the beginning of the directory path will be replaced"
     echo "  with the sysroot directory path."
     echo ""
     echo "Environment variables:"
-    echo "  CMAKE_TOOLCHAIN_FILE - Default toolchain file"
+    echo "  CMAKE_TOOLCHAIN_FILE - CMake toolchain file"
+    echo "  HOST_INSTALL - host system dependencies"
     echo "  SDKTARGETSYSROOT - sysroot directory"
     echo ""
 }
@@ -74,13 +81,19 @@ print_cmake_params() {
     [ -n "${_GENERATOR}" ] && echo "${_GENERATOR}"
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
     echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
-    echo "JOBS=${_NJOBS}"
-    [ -n "${_CXX_STANDARD_OPTION}" ] && echo "${_CXX_STANDARD_OPTION:2}"
+    [ -n "${_CXX_STD}" ] && echo "CXX_STANDARD=${_CXX_STD}"
     [ -n "${_DOWNLOAD}" ] && echo "${_DOWNLOAD:2}"
     [ -n "${_HOST_DEPEND_DIR}" ] && echo "${_HOST_DEPEND_DIR:2}"
+    [ -n "${_PATCH}" ] && echo "${_PATCH:2}"
     [ -n "${_FORCE_PATCH}" ] && echo "${_FORCE_PATCH:2}"
     [ -n "${_USE_SUDO}" ] && echo "${_USE_SUDO:2}"
-    echo ""
+    echo "-B ${_BLD_DIR}"
+    if [ ${_CFG_ONLY} -ne 0 ]; then
+        echo ""
+        echo "Configure without building"
+        return
+    fi
+    echo "-j${_NJOBS}"
 }
 
 ######################
@@ -90,8 +103,9 @@ print_cmake_params() {
 SHORTOPTS=B:H:P:T:j:
 SHORTOPTS=${SHORTOPTS}hn
 
-LONGOPTS=build:,cxx:,hostdeps:,jobs:,prefix:,toolchain:
-LONGOPTS=${LONGOPTS},config,dry-run,force,help,ninja,no-download,sudo
+LONGOPTS=build:,cxx-std:,hostdeps:,jobs:,prefix:,toolchain:
+LONGOPTS=${LONGOPTS},config,dry-run,force,help,ninja
+LONGOPTS=${LONGOPTS},no-download,no-patch,sudo
 
 GETOPTS=$(getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@")
 eval set -- "${GETOPTS}"
@@ -99,35 +113,35 @@ eval set -- "${GETOPTS}"
 while true ; do
     case "$1" in
     # Paths
-    -B|--build)
+    --build|-B)
         _BLD_DIR=$2
         shift 2 ;;
-    -H|--hostdeps)
+    --hostdeps|-H)
         _HOST_DIR=$2
         shift 2 ;;
-    -P|--prefix)
+    --prefix|-P)
         _PREFIX=$2
         shift 2 ;;
-    -T|--toolchain)
+    --toolchain|-T)
         _TOOLFILE=$2
         shift 2 ;;
     # Options
     --config)
-        _CFG_ONLY=true
+        _CFG_ONLY=1
         shift ;;
-    --cxx)
-        _CXX_STANDARD_OPTION="-DCXX_STANDARD=$2"
+    --cxx-std)
+        _CXX_STD=$2
         shift 2 ;;
     --dry-run|-n)
-        _DRY_RUN=true
+        _DRY_RUN=1
         shift ;;
-    -f|--force)
+    --force|-f)
         _FORCE_PATCH="-DFORCE_PATCH=TRUE"
         shift ;;
-    -h|--help)
+    --help|-h)
         print_help
         exit 99 ;;
-    -j|--jobs)
+    --jobs|-j)
         _NJOBS=$2
         shift 2 ;;
     --ninja)
@@ -135,6 +149,9 @@ while true ; do
         shift ;;
     --no-download)
         _DOWNLOAD="-DDOWNLOAD=FALSE"
+        shift ;;
+    --no-patch)
+        _PATCH="-DPATCH=FALSE"
         shift ;;
     --sudo)
         _USE_SUDO="-DUSE_SUDO=TRUE"
@@ -155,13 +172,13 @@ done
 # Replace "//"" prefix with "${_SYSROOT}/""
 [ "${_PREFIX:0:2}" = "//" ] && _PREFIX="${_SYSROOT}/${_PREFIX:2}"
 
-if [ -n "${_HOST_DIR}" ]; then
-    _HOST_DEPEND_DIR="-DHOST_DEPEND_DIR=${_HOST_DIR}"
-fi
+[ -n "${_CXX_STD}" ] && _CXX_STANDARD="-DCXX_STANDARD=${_CXX_STD}"
+[ -n "${_HOST_DIR}" ] && _HOST_DEPEND_DIR="-DHOST_DEPEND_DIR=${_HOST_DIR}"
 
 # Show parameters if this is a dry run
-if [ "${_DRY_RUN}" = "true" ]; then
+if [ ${_DRY_RUN} -ne 0 ]; then
     print_cmake_params
+    echo ""
     exit 0
 fi
 
@@ -169,16 +186,21 @@ fi
 # Build dependencies #
 ######################
 
-rm -fr ${_BLD_DIR}
+rm -fr "${_BLD_DIR}"
 
-cmake -S . -B ${_BLD_DIR} \
-    "${_GENERATOR}" \
-    -DCMAKE_INSTALL_PREFIX=${_PREFIX} \
-    -DCMAKE_TOOLCHAIN_FILE=${_TOOLFILE} \
+# shellcheck disable=SC2086
+cmake -S . -B "${_BLD_DIR}" \
+    ${_GENERATOR} \
+    -DCMAKE_INSTALL_PREFIX="${_PREFIX}" \
+    -DCMAKE_TOOLCHAIN_FILE="${_TOOLFILE}" \
+    ${_CXX_STANDARD} \
     ${_HOST_DEPEND_DIR} \
-    ${_CXX_STANDARD_OPTION} \
-    ${_DOWNLOAD} ${_FORCE_PATCH} ${_USE_SUDO}
+    ${_DOWNLOAD} \
+    ${_PATCH} \
+    ${_FORCE_PATCH} \
+    ${_USE_SUDO}
 
-if [ "${_CFG_ONLY}" = "false" ]; then
-    cmake --build ${_BLD_DIR} -j${_NJOBS}
+if [ ${_CFG_ONLY} -ne 0 ]; then
+    # shellcheck disable=SC2086
+    cmake --build "${_BLD_DIR}" -j${_NJOBS}
 fi

--- a/scripts/make-host-deps.sh
+++ b/scripts/make-host-deps.sh
@@ -38,7 +38,6 @@ fi
 # Default values #
 ##################
 
-_BLD_TYPE="Release"
 _BLD_DIR=build
 _CFG_ONLY=0
 _DRY_RUN=0
@@ -72,9 +71,8 @@ print_help() {
     echo ""
     echo "Configurations:"
     echo "  --debug             Debug configuration"
-    echo "  --minsize           MinSizeRel configuration"
     echo "  --reldeb            RelWithDebInfo configuration"
-    echo "  --release           Release configuration (default)"
+    echo "  --release           Release configuration"
     echo ""
 }
 
@@ -85,7 +83,7 @@ print_help() {
 print_cmake_params() {
     echo ""
     [ -n "${_GENERATOR}" ] && echo "${_GENERATOR}"
-    echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
+    [ -n "${_BUILD_TYPE}" ] && echo "${_BUILD_TYPE:2}"
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
     [ -n "${_CXX_STD}" ] && echo "CXX_STANDARD=${_CXX_STD}"
     [ -n "${_ON_DEMAND}" ] && echo "${_ON_DEMAND:2}"
@@ -113,7 +111,7 @@ config_build() {
     # shellcheck disable=SC2086
     cmake -S . -B "${_BLD_DIR}" \
         ${_GENERATOR} \
-        -DCMAKE_BUILD_TYPE="${_BLD_TYPE}" \
+        ${_BUILD_TYPE} \
         -DCMAKE_INSTALL_PREFIX="${_PREFIX}" \
         ${_CXX_STANDARD} \
         ${_ON_DEMAND} \
@@ -130,7 +128,7 @@ SHORTOPTS=B:P:j:
 SHORTOPTS=${SHORTOPTS}fhn
 
 LONGOPTS=build:,cxx-std:,jobs:,prefix:
-LONGOPTS=${LONGOPTS},debug,release,minsize,reldeb
+LONGOPTS=${LONGOPTS},debug,release,reldeb
 LONGOPTS=${LONGOPTS},config,dry-run,force,full,help,minimal,ninja
 LONGOPTS=${LONGOPTS},no-download,no-patch,sudo
 
@@ -148,16 +146,13 @@ while true ; do
         shift 2 ;;
     # Configurations
     --debug)
-        _BLD_TYPE="Debug"
-        shift ;;
-    --minsize)
-        _BLD_TYPE="MinSizeRel"
+        _BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug"
         shift ;;
     --reldeb)
-        _BLD_TYPE="RelWithDebInfo"
+        _BUILD_TYPE="-DCMAKE_BUILD_TYPE=RelWithDebInfo"
         shift ;;
     --release)
-        _BLD_TYPE="Release"
+        _BUILD_TYPE="-DCMAKE_BUILD_TYPE=Release"
         shift ;;
     # Options
     --config)


### PR DESCRIPTION
- Implement --no-patch option. (make-cross-deps)

- Add support for HOST_INSTALL environment variable. (make-cross-deps)

- Change default build scope from --minimal to --full. (make-host-deps)

- Clean up implementation of --cxx option.

- Swap long and short option names in case labels.

- Address shellcheck issues.

- Implement support for the --debug (Debug), --release (Release),
  and --reldeb (RelWithDebInfo) configuration options.

- Change default build configuration to Release.
