### PR TITLE
Stratum Dependencies build guide

### DIFF
--- a/docs/building-acc-stratum-deps.md
+++ b/docs/building-acc-stratum-deps.md
@@ -22,7 +22,7 @@ You will need to build two versions of the libraries:
 
 The Host and Target libraries must be the same version.
 
-## Prerequisites
+## Requirements
 
 Before you build the dependencies, you need to:
 
@@ -39,7 +39,7 @@ Before you build the dependencies, you need to:
   See [Installing the ACC SDK](https://ipdk.io/p4cp-userguide/guides/es2k/installing-acc-sdk)
   for directions.
 
-## Source code
+## Source
 
 Clone this repository to your development system:
 
@@ -47,8 +47,8 @@ Clone this repository to your development system:
 git clone https://github.com/ipdk-io/stratum-deps.git
 ```
 
-The CMake script will download the source code for the libraries as the
-first step in the build.
+The build procedure will download the source code for the libraries
+as needed.
 
 ## Host dependencies
 
@@ -86,7 +86,7 @@ The Host and Target build environments are mutually incompatible.
 To install the dependencies in a user directory:
 
 ```bash
-./make-host-deps.sh --prefix=PREFIX
+./scripts/make-host-deps.sh --prefix=PREFIX
 ```
 
 PREFIX might something like `~/hostdeps`.
@@ -100,7 +100,7 @@ To install the Host dependencies in a system directory, log in as `root`
 or build from an account that has `sudo` privilege.
 
 ```bash
-./make-host-deps.sh --prefix=PREFIX --sudo
+./scripts/make-host-deps.sh --prefix=PREFIX --sudo
 ```
 
 PREFIX might be something like `/opt/ipdk/x86deps`.
@@ -138,22 +138,16 @@ variables needed for cross-compilation.
 
 ### Target build
 
-Source the file that the defines the ACC build environment.
+Source the file that the defines the ACC build environment:
 
 ```bash
 source acc-setup.env
 ```
 
-Remove the `build` directory from the previous build.
+Run the build script:
 
 ```bash
-rm -fr build
-```
-
-Run the build script.
-
-```bash
-./make-cross-deps.sh --host=HOSTDEPS --prefix=PREFIX
+./scripts/make-cross-deps.sh --host=HOSTDEPS --prefix=PREFIX
 ```
 
 `HOSTDEPS` is the path to the Host dependencies, e.g., `~/p4cp-dev/hostdeps`.

--- a/docs/building-acc-target-deps.md
+++ b/docs/building-acc-target-deps.md
@@ -1,10 +1,10 @@
-# Building Stratum dependencies for the ACC
+# Building ACC Target Dependencies
 
 This document explains how to build the Stratum dependencies for the
 ARM Compute Complex (ACC) of the Intel&reg; IPU E2100.
 
-> **Note**: To build the dependencies for a different target, see
-[Building Stratum dependencies](building-stratum-deps.md).
+> **Note**: To build the dependencies for the Host system, see
+[Building Host Dependencies](building-host-deps.md).
 
 ## Introduction
 

--- a/docs/building-host-deps.md
+++ b/docs/building-host-deps.md
@@ -1,4 +1,4 @@
-# Building Stratum dependencies
+# Building Host Dependencies
 
 Stratum is the component of `infrap4d` that implements the P4Runtime and gNMI
 (OpenConfig) services. It requires  a number of third-party libraries, which
@@ -6,8 +6,9 @@ this package provides.
 
 This document explains how to build and install the Stratum dependencies.
 
-> **Note**: For the Intel&reg; IPU E2100, see
-[Building Stratum dependencies for the ACC](building-acc-stratum-deps.md).
+> **Note**: To build dependencies for the Arm Compute Complex (ACC) of the
+Intel&reg; IPU E2100, see
+[Building ACC Target Dependencies](building-acc-target-deps.md).
 
 ## Prerequisites
 

--- a/docs/change-history.md
+++ b/docs/change-history.md
@@ -1,11 +1,11 @@
 # Change History
 
 This document summarizes the changes that have been made in the transtion
-from `networking-recipe/setup` to a standlone repository.
+from `networking-recipe/setup` to the `stratum-deps` repository.
 
 ## General changes
 
-### CMake list files
+### CMake listfiles
 
 - Change the default build type to Release.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,32 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Stratum Dependencies'
+copyright = '2022-2023, Intel Corporation'
+author = 'Intel Corporation'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+import sphinx_rtd_theme
+
+extensions = [
+    'myst_parser',          # markdown parser
+    'sphinx_rtd_theme'      # ReadTheDocs theme
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['CONTRIBUTING.rst']
+
+myst_heading_anchors = 3
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+#html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,27 @@
+.. Copyright 2023 Intel Corporation
+   SPDX-License-Identifier: Apache-2.0
+
+================================
+Stratum Dependencies Build Guide
+================================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Building
+
+   defining-acc-environment
+   building-host-deps
+   building-acc-target-deps
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Helper scripts
+
+   make-cross-deps
+   make-host-deps
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Project
+
+   change-history

--- a/docs/make-cross-deps.rst
+++ b/docs/make-cross-deps.rst
@@ -1,9 +1,9 @@
+.. Copyright 2023 Intel Corporation
+   SPDX-License-Identifier: Apache 2.0
+
 ==================
 make-cross-deps.sh
 ==================
-
-.. Copyright 2023 Intel Corporation
-   SPDX-License-Identifier: Apache 2.0
 
 Helper script to build and install the Stratum dependencies for the
 Arm Compute Complex (ACC).

--- a/docs/make-cross-deps.rst
+++ b/docs/make-cross-deps.rst
@@ -23,13 +23,6 @@ Syntax
       [--toolchain=TOOLFILE | -T TOOLFILE ] \
       [--jobs=NJOBS | -j NJOBS]
 
-Variables
-=========
-
-* A variable whose name begins with ``CMAKE_`` is defined by CMake.
-
-* A *listfile variable* is defined by the CMakeLists.txt file.
-
 Command-line parameters
 =======================
 
@@ -109,6 +102,21 @@ Options
 ``--sudo``
   Requests that ``sudo`` be used when installing the dependencies.
   The ``USE_SUDO`` listfile variable will be set to TRUE.
+
+Configurations
+--------------
+
+``--debug``
+  Build with ``-DCMAKE_BUILD_TYPE=Debug``.
+  The compiler settings will default to ``-g``.
+
+``--reldeb``
+  Build with ``-DCMAKE_BUILD_TYPE=RelWithDebInfo``.
+  The compiler settings will default to ``-O2 -g -DNDEBUG``.
+
+``--release``
+  Build with ``-DCMAKE_BUILD_TYPE=Release``.
+  The compiler settings will default to ``-O3 -DNDEBUG``.
 
 Environment variables
 =====================

--- a/docs/make-host-deps.rst
+++ b/docs/make-host-deps.rst
@@ -1,9 +1,9 @@
+.. Copyright 2023 Intel Corporation
+   SPDX-License-Identifier: Apache 2.0
+
 =================
 make-host-deps.sh
 =================
-
-.. Copyright 2023 Intel Corporation
-   SPDX-License-Identifier: Apache 2.0
 
 Helper script to build and install the Stratum dependencies for the
 x86 build system.

--- a/docs/make-host-deps.rst
+++ b/docs/make-host-deps.rst
@@ -99,11 +99,26 @@ Options
   Requests that ``sudo`` be used when installing the dependencies.
   The ``USE_SUDO`` listfile variable will be set to TRUE.
 
+Configurations
+--------------
+
+``--debug``
+  Build with ``-DCMAKE_BUILD_TYPE=Debug``.
+  The compiler settings will default to ``-g``.
+
+``--reldeb``
+  Build with ``-DCMAKE_BUILD_TYPE=RelWithDebInfo``.
+  The compiler settings will default to ``-O2 -g -DNDEBUG``.
+
+``--release``
+  Build with ``-DCMAKE_BUILD_TYPE=Release``.
+  The compiler settings will default to ``-O3 -DNDEBUG``.
+
 Examples
 ========
 
-Build as an non-privileged user
--------------------------------
+Install as non-privileged user
+------------------------------
 
 To build the dependencies and install them in a user directory:
 
@@ -114,8 +129,8 @@ To build the dependencies and install them in a user directory:
 The source files will be downloaded and built, and the results will be
 installed in the ``~/hostdeps`` directory.
 
-Non-root build to a system directory
-------------------------------------
+Install to system directory (non-root)
+--------------------------------------
 
 To install the Host dependencies in a system directory, log in as ``root``
 or build from an account that has ``sudo`` privilege.
@@ -127,8 +142,8 @@ or build from an account that has ``sudo`` privilege.
 CMake will build the dependencies as the current user and use ``sudo`` to
 install the libraries in ``/opt/deps``.
 
-Build and install as root
--------------------------
+Install to system directory (root)
+----------------------------------
 
 To build and install to a system directory when logged in as ``root``:
 
@@ -150,3 +165,27 @@ another build without downloading again:
 
 The libraries will be built and installed in ``./hostdeps`` without
 downloading or patching the source code.
+
+Verify parameter settings
+-------------------------
+
+You can use the ``--dry-run`` or ``-n`` option to review the cmake parameter
+settings your build will use:
+
+.. code-block:: bash
+
+  ~/stratum-deps$ ./scripts/make-host-deps.sh -B build.host -j6 \
+      --no-download --no-patch --debug -n
+
+  CMAKE_BUILD_TYPE=Debug
+  CMAKE_INSTALL_PREFIX=hostdeps
+  DOWNLOAD=FALSE
+  PATCH=FALSE
+  -B build.host
+  -j6
+
+  Will perform a full build
+
+  ~/stratum-deps$
+
+No other action will be taken.


### PR DESCRIPTION
Set up Sphinx framework for Stratum Dependencies documents.

It is expected that these documents will eventually be merged into the P4 Control Plane User Guide.