### PR TITLE
Edit documentation

### DIFF
--- a/docs/building-acc-target-deps.md
+++ b/docs/building-acc-target-deps.md
@@ -71,15 +71,11 @@ can be used to build the Host dependencies.
 - The `--dry-run` (`-n`) option displays the parameter values without
   running CMake
 
-The script normally does a minimal build, containing just the components
-needed for cross-compilation. Specify the `--full` parameter if you want
-to build all the libraries.
-
 ### Host build environment
 
 The Host and Target build environments are mutually incompatible.
- You must ensure that the  [ACC build environment](defining-acc-environment.md)
- is undefined when you build the Host dependencies.
+You must ensure that the [ACC build environment](defining-acc-environment.md)
+is undefined when you build the Host dependencies.
 
 ### User build
 

--- a/docs/make-cross-deps.rst
+++ b/docs/make-cross-deps.rst
@@ -26,8 +26,8 @@ Syntax
 Command-line parameters
 =======================
 
-Help
-----
+General
+-------
 
 ``--dry-run``, ``-n``
   Displays the parameters that will be passed to CMake, and exits.
@@ -129,7 +129,7 @@ Environment variables
 
 ``HOST_INSTALL``
   Directory in which the Stratum dependencies for the host system were
-  installed
+  installed.
   Specifies the default value of the ``--host`` option.
 
 ``SDKTARGETSYSROOT``

--- a/docs/make-cross-deps.rst
+++ b/docs/make-cross-deps.rst
@@ -72,7 +72,7 @@ Options
   Configures CMake but does not build the dependencies.
   Can be used to verify the parameter settings that will be used.
 
-``cxx=STD``
+``--cxx=STD``
   C++ standard to be used by the compiler (11, 14, 17).
   Specifies the value of the ``CXX_STANDARD`` listfile variable.
 

--- a/docs/make-host-deps.rst
+++ b/docs/make-host-deps.rst
@@ -58,7 +58,7 @@ Options
   Configures CMake but does not build the dependencies.
   Can be used to verify the parameter settings that will be used.
 
-``cxx=STD``
+``--cxx=STD``
   C++ standard to be used by the compiler (11, 14, 17).
   Specifies the value of the ``CXX_STANDARD`` listfile variable.
 

--- a/docs/make-host-deps.rst
+++ b/docs/make-host-deps.rst
@@ -25,8 +25,8 @@ Syntax
 Command-line parameters
 =======================
 
-Help
-----
+General
+-------
 
 ``--dry-run``, ``-n``
   Displays the parameters that will be passed to CMake, and exits.


### PR DESCRIPTION
- Remove statement that the `make-host-deps` script normally does a minimal build. The default has been changed to a full build.

- Make some minor spacing fixes.