### PR TITLE
Augment pruning scripts

### DIFF
--- a/scripts/prune.sh
+++ b/scripts/prune.sh
@@ -22,5 +22,9 @@ rm -fr ${SOURCE_DIR}/protobuf/third_party/abseil-cpp
 rm -fr ${SOURCE_DIR}/protobuf/third_party/zlib
 
 # unused packages
+rm -fr ${SOURCE_DIR}/grpc/third_party/benchmark
 rm -fr ${SOURCE_DIR}/grpc/third_party/bloaty
 rm -fr ${SOURCE_DIR}/grpc/third_party/boringssl-with-bazel
+rm -fr ${SOURCE_DIR}/grpc/third_party/libuv
+
+rm -fr ${SOURCE_DIR}/protobuf/third_party/benchmark

--- a/scripts/rmgit.sh
+++ b/scripts/rmgit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+# Removes git directories and files
+#
+
+SOURCE_DIR=source
+
+find ${SOURCE_DIR} -name .git -exec rm -fr {} +
+find ${SOURCE_DIR} -name .gitattributes -exec rm {} +
+find ${SOURCE_DIR} -name .gitignore -exec rm {} +
+find ${SOURCE_DIR} -name .gitmodules -exec rm {} +


### PR DESCRIPTION
- Modify prune.sh to remove the 'benchmark' and 'libuv' submodules.

- Create `rmgit.sh` script to remove git directories and files.