### PR TITLE
Change --config option to --no-build

### DIFF
--- a/docs/change-history.md
+++ b/docs/change-history.md
@@ -37,7 +37,7 @@ transition from `networking-recipe/setup` to the `stratum-deps` repository.
 - Implement `--debug`, `--release`, and `--reldeb` options to specify
   the CMake build configuration.
 
-- Implement `--config` option to configure cmake without building.
+- Implement `--no-build` option to configure cmake without building.
 
 - Change default build scope from `--minimal` to `--full`.
   (make-host-deps)

--- a/docs/make-cross-deps.rst
+++ b/docs/make-cross-deps.rst
@@ -15,7 +15,7 @@ Syntax
 
   ./scripts/make-cross-deps.sh \
       [--help | -h]  [--dry-run -n] \
-      [--config]  [--cxx=STD] [--sudo] \
+      [--no-build]  [--cxx=STD] [--sudo] \
       [--no-download]  [--no-patch] \
       [--build=BLDDIR | -B BLDDIR] \
       [--host=HOSTDEPS | -H HOSTDEPS] \
@@ -68,17 +68,12 @@ Paths
 Options
 -------
 
-``--config``
-  Configures CMake but does not build the dependencies.
-  Can be used to verify the parameter settings that will be used.
-
 ``--cxx=STD``
   C++ standard to be used by the compiler (11, 14, 17).
   Specifies the value of the ``CXX_STANDARD`` listfile variable.
 
 ``--force``, ``-f``
-  Requests that the ``-f`` (force) option be used when patching a
-  downloaded repository.
+  Use the ``-f`` (force) option when patching a downloaded repository.
   Specifies the value of the ``FORCE_PATCH`` listfile variable.
   Deprecated. If the repositories have already been patched, the
   ``--no-patch`` option bypasses the patch stage entirely.
@@ -87,6 +82,9 @@ Options
   Number of build threads.
   Specifies the value of the ``-j`` CMake option.
   Defaults to 8.
+
+``--no-build``
+  Configure CMake but do not build the dependencies.
 
 ``--no-download``
   Do not download the repositories.
@@ -100,7 +98,7 @@ Options
   The ``PATCH`` listfile variable will be set to FALSE.
 
 ``--sudo``
-  Requests that ``sudo`` be used when installing the dependencies.
+  Use ``sudo`` when installing the dependencies.
   The ``USE_SUDO`` listfile variable will be set to TRUE.
 
 Configurations

--- a/docs/make-host-deps.rst
+++ b/docs/make-host-deps.rst
@@ -15,7 +15,7 @@ Syntax
 
   ./scripts/make-host-deps.sh \
       [--help | -h]  [--dry-run | -n] \
-      [--config]  [--cxx=STD] [--sudo] \
+      [--no-build]  [--cxx=STD] [--sudo] \
       [--no-download]  [--no-patch] \
       [--minimal | --full] \
       [--build=BLDDIR | -B BLDDIR] \
@@ -54,10 +54,6 @@ Paths
 Options
 -------
 
-``--config``
-  Configures CMake but does not build the dependencies.
-  Can be used to verify the parameter settings that will be used.
-
 ``--cxx=STD``
   C++ standard to be used by the compiler (11, 14, 17).
   Specifies the value of the ``CXX_STANDARD`` listfile variable.
@@ -84,6 +80,9 @@ Options
   cross-compilation environment.
   The opposite of ``--full``, which is the default.
 
+``--no-build``
+  Configure CMake but do not build the dependencies.
+
 ``--no-download``
   Do not download the repositories.
   Use this option if building from a source package or from source that was
@@ -96,7 +95,7 @@ Options
   The ``PATCH`` listfile variable will be set to FALSE.
 
 ``--sudo``
-  Requests that ``sudo`` be used when installing the dependencies.
+  Use ``sudo`` when installing the dependencies.
   The ``USE_SUDO`` listfile variable will be set to TRUE.
 
 Configurations

--- a/scripts/make-cross-deps.sh
+++ b/scripts/make-cross-deps.sh
@@ -31,7 +31,7 @@ _SYSROOT=${SDKTARGETSYSROOT}
 ##################
 
 _BLD_DIR=build
-_CFG_ONLY=0
+_DO_BUILD=1
 _DRY_RUN=0
 _HOST_DIR=${HOST_INSTALL}
 _NJOBS=8
@@ -56,11 +56,11 @@ print_help() {
     echo "  with the sysroot directory path."
     echo ""
     echo "Options:"
-    echo "  --config             Configure without building"
     echo "  --cxx=STD            C++ standard to be used [${_CXX_STD}]"
     echo "  --dry-run        -n  Display cmake parameters and exit"
     echo "  --force          -f  Specify -f when patching (deprecated)"
     echo "  --jobs=NJOBS     -j  Number of build threads [${_NJOBS}]"
+    echo "  --no-build           Configure without building"
     echo "  --no-download        Do not download repositories"
     echo "  --no-patch           Do not patch source after downloading"
     echo "  --sudo               Use sudo when installing"
@@ -94,7 +94,7 @@ print_cmake_params() {
     [ -n "${_FORCE_PATCH}" ] && echo "${_FORCE_PATCH:2}"
     [ -n "${_USE_SUDO}" ] && echo "${_USE_SUDO:2}"
     echo "-B ${_BLD_DIR}"
-    if [ ${_CFG_ONLY} -ne 0 ]; then
+    if [ ${_DO_BUILD} -eq 0 ]; then
         echo ""
         echo "Configure without building"
         return
@@ -131,8 +131,8 @@ SHORTOPTS=${SHORTOPTS}hn
 LONGOPTS=build:,hostdeps:,prefix:,toolchain:
 LONGOPTS=${LONGOPTS},cxx-std:,jobs:
 LONGOPTS=${LONGOPTS},debug,release,reldeb
-LONGOPTS=${LONGOPTS},config,dry-run,force,help,ninja
-LONGOPTS=${LONGOPTS},no-download,no-patch,sudo
+LONGOPTS=${LONGOPTS},dry-run,force,help,ninja
+LONGOPTS=${LONGOPTS},no-build,no-download,no-patch,sudo
 
 GETOPTS=$(getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@")
 eval set -- "${GETOPTS}"
@@ -163,9 +163,6 @@ while true ; do
         _BUILD_TYPE="-DCMAKE_BUILD_TYPE=Release"
         shift ;;
     # Options
-    --config)
-        _CFG_ONLY=1
-        shift ;;
     --cxx-std)
         _CXX_STD=$2
         shift 2 ;;
@@ -183,6 +180,9 @@ while true ; do
         shift 2 ;;
     --ninja)
         _GENERATOR="-G Ninja"
+        shift ;;
+    --no-build)
+        _DO_BUILD=0
         shift ;;
     --no-download)
         _DOWNLOAD="-DDOWNLOAD=FALSE"
@@ -227,7 +227,7 @@ rm -fr "${_BLD_DIR}"
 
 config_build
 
-if [ ${_CFG_ONLY} -ne 0 ]; then
+if [ ${_DO_BUILD} -ne 0 ]; then
     # shellcheck disable=SC2086
     cmake --build "${_BLD_DIR}" -j${_NJOBS}
 fi


### PR DESCRIPTION
- Rename the --config option to --no-build. It's more consistent with the other options (e.g., --no-patch), in that it disables an action the script would normally take, and its meaning is more obvious.

  This also frees up --config for a different use.

- Update documentation to reflect the above change. Also change the descriptions of several options from passive voice to active voice.