### PR TITLE
Rename GetDownloadSpec to GetDownloadClause

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,15 +134,15 @@ endif()
 
 function(GetDownloadClause VAR _url _tag)
   if(DOWNLOAD)
-    set(_spec
+    set(_clause
       GIT_REPOSITORY  ${_url}
       GIT_TAG         ${_tag}
       GIT_PROGRESS    ON
     )
   else()
-    set(_spec "")
+    set(_clause "")
   endif()
-  set(${VAR} ${_spec} PARENT_SCOPE)
+  set(${VAR} ${_clause} PARENT_SCOPE)
 endfunction(GetDownloadClause)
 
 #-----------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,14 +125,14 @@ elseif(NOT CMAKE_CROSSCOMPILING)
 endif()
 
 #-----------------------------------------------------------------------
-# GetDownloadSpec
+# GetDownloadClause
 #
 # Generates the ExternalProject_Add() parameters needed to download
 # a git repository and returns them in the VAR parameter. Returns an
 # empty string if the DOWNLOAD option is false.
 #-----------------------------------------------------------------------
 
-function(GetDownloadSpec VAR _url _tag)
+function(GetDownloadClause VAR _url _tag)
   if(DOWNLOAD)
     set(_spec
       GIT_REPOSITORY  ${_url}
@@ -143,7 +143,7 @@ function(GetDownloadSpec VAR _url _tag)
     set(_spec "")
   endif()
   set(${VAR} ${_spec} PARENT_SCOPE)
-endfunction(GetDownloadSpec)
+endfunction(GetDownloadClause)
 
 #-----------------------------------------------------------------------
 # Dependencies

--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -13,10 +13,10 @@ if(DEFINED CURRENT_CXX_STANDARD AND NOT CURRENT_CXX_STANDARD STREQUAL "")
   )
 endif()
 
-GetDownloadSpec(DOWNLOAD_ABSL ${ABSEIL_GIT_URL} ${ABSEIL_GIT_TAG})
+GetDownloadClause(_download_clause ${ABSEIL_GIT_URL} ${ABSEIL_GIT_TAG})
 
 ExternalProject_Add(abseil-cpp
-  ${DOWNLOAD_ABSL}
+  ${_download_clause}
 
   SOURCE_DIR
     ${DEPS_SOURCE_DIR}/abseil-cpp

--- a/cmake/c-ares.cmake
+++ b/cmake/c-ares.cmake
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GetDownloadSpec(DOWNLOAD_CARES ${CARES_GIT_URL} ${CARES_GIT_TAG})
+GetDownloadClause(_download_clause ${CARES_GIT_URL} ${CARES_GIT_TAG})
 
 ExternalProject_Add(cares
-  ${DOWNLOAD_CARES}
+  ${_download_clause}
 
   SOURCE_DIR
     ${DEPS_SOURCE_DIR}/c-ares

--- a/cmake/cctz.cmake
+++ b/cmake/cctz.cmake
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GetDownloadSpec(DOWNLOAD_CCTZ ${CCTZ_GIT_URL} ${CCTZ_GIT_TAG})
+GetDownloadClause(_download_clause ${CCTZ_GIT_URL} ${CCTZ_GIT_TAG})
 
 ExternalProject_Add(cctz
-  ${DOWNLOAD_CCTZ}
+  ${_download_clause}
 
   SOURCE_DIR
     ${DEPS_SOURCE_DIR}/cctz

--- a/cmake/gflags.cmake
+++ b/cmake/gflags.cmake
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GetDownloadSpec(DOWNLOAD_GFLAGS ${GFLAGS_GIT_URL} ${GFLAGS_GIT_TAG})
+GetDownloadClause(_download_clause ${GFLAGS_GIT_URL} ${GFLAGS_GIT_TAG})
 
 ExternalProject_Add(gflags
-  ${DOWNLOAD_GFLAGS}
+  ${_download_clause}
 
   SOURCE_DIR
     ${DEPS_SOURCE_DIR}/gflags

--- a/cmake/glog.cmake
+++ b/cmake/glog.cmake
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GetDownloadSpec(DOWNLOAD_GLOG ${GLOG_GIT_URL} ${GLOG_GIT_TAG})
+GetDownloadClause(_download_clause ${GLOG_GIT_URL} ${GLOG_GIT_TAG})
 
 ExternalProject_Add(glog
-  ${DOWNLOAD_GLOG}
+  ${_download_clause}
 
   SOURCE_DIR
     ${DEPS_SOURCE_DIR}/glog

--- a/cmake/grpc.cmake
+++ b/cmake/grpc.cmake
@@ -46,8 +46,6 @@ if(DEFINED CURRENT_CXX_STANDARD AND NOT CURRENT_CXX_STANDARD STREQUAL "")
   set(_grpc_cxx_standard -DCMAKE_CXX_STANDARD=${CURRENT_CXX_STANDARD})
 endif()
 
-GetDownloadSpec(_download_clause ${GRPC_GIT_URL} ${GRPC_GIT_TAG})
-
 if(OVERRIDE_PKGS)
   set(_package_providers
     -DgRPC_ABSL_PROVIDER=package
@@ -63,6 +61,8 @@ if(OVERRIDE_PKGS)
       zlib
   )
 endif()
+
+GetDownloadClause(_download_clause ${GRPC_GIT_URL} ${GRPC_GIT_TAG})
 
 ExternalProject_Add(grpc
   ${_download_clause}

--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GetDownloadSpec(DOWNLOAD_GTEST ${GTEST_GIT_URL} ${GTEST_GIT_TAG})
+GetDownloadClause(_download_clause ${GTEST_GIT_URL} ${GTEST_GIT_TAG})
 
 ExternalProject_Add(gtest
-  ${DOWNLOAD_GTEST}
+  ${_download_clause}
 
   SOURCE_DIR
     ${DEPS_SOURCE_DIR}/gtest

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GetDownloadSpec(DOWNLOAD_JSON ${JSON_GIT_URL} ${JSON_GIT_TAG})
+GetDownloadClause(_download_clause ${JSON_GIT_URL} ${JSON_GIT_TAG})
 
 ExternalProject_Add(json
-  ${DOWNLOAD_JSON}
+  ${_download_clause}
 
   SOURCE_DIR
     ${DEPS_SOURCE_DIR}/json

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -8,8 +8,6 @@ unset(_absl_provider)
 unset(_build_shared_libs)
 unset(_source_subdir)
 
-GetDownloadSpec(DOWNLOAD_PROTOBUF ${PROTOBUF_GIT_URL} ${PROTOBUF_GIT_TAG})
-
 # In older versions of protobuf, the primary CMakeLists.txt file
 # is in the cmake subdirectory.
 if(NOT RECENT_PKGS)
@@ -31,8 +29,10 @@ if(RECENT_PKGS)
   set(_absl_provider -Dprotobuf_ABSL_PROVIDER=package)
 endif()
 
+GetDownloadClause(_download_clause ${PROTOBUF_GIT_URL} ${PROTOBUF_GIT_TAG})
+
 ExternalProject_Add(protobuf
-  ${DOWNLOAD_PROTOBUF}
+  ${_download_clause}
 
   SOURCE_DIR
     ${DEPS_SOURCE_DIR}/protobuf

--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GetDownloadSpec(DOWNLOAD_ZLIB ${ZLIB_GIT_URL} ${ZLIB_GIT_TAG})
+GetDownloadClause(_download_clause ${ZLIB_GIT_URL} ${ZLIB_GIT_TAG})
 
 ExternalProject_Add(zlib
-  ${DOWNLOAD_ZLIB}
+  ${_download_clause}
 
   SOURCE_DIR
     ${DEPS_SOURCE_DIR}/zlib


### PR DESCRIPTION
- Rename the GetDownloadSpec() cmake function to GetDownloadClause().

Improve the readability of the build system by:

- Giving the function a name that better describes what it does.
- Using an output variable name (`_download_clause`) that is more obviously local to the file in which it appears, and that better describes its purpose.