### PR TITLE
Implement presets file

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -42,6 +42,9 @@ jobs:
           find . -name '.git*' -exec rm -fr {} +
           rm -fr build/
 
+      - name: Create presets file
+        run: ./scripts/create-presets.sh
+
       - name: Create tarballs
         run: |
           tar -czf /tmp/deps-source.tar.gz -C .. stratum-deps/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# generated files
-grpc.patch
-
 # build directories
 /build
 
@@ -8,7 +5,7 @@ grpc.patch
 /*deps*/
 /install
 
-# download directories
+# downloaded source
 source
 
 # editor directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Version 3.15 is the baseline for P4 Control Plane.
 cmake_minimum_required(VERSION 3.15)
 
-project(stratum-deps VERSION 1.2.0 LANGUAGES C CXX)
+project(stratum-deps VERSION 1.2.1 LANGUAGES C CXX)
 
 include(ExternalProject)
 include(CMakePrintHelpers)
@@ -22,6 +22,10 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.24 AND
 endif()
 
 cmake_print_variables(CMAKE_PROJECT_VERSION)
+
+if(EXISTS source/presets.cmake)
+  include(source/presets.cmake)
+endif()
 
 #-----------------------------------------------------------------------
 # Options

--- a/scripts/create-presets.sh
+++ b/scripts/create-presets.sh
@@ -1,0 +1,18 @@
+# Copyright 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Creates a cmake include file (source/presets.cmake) that disables the
+# DOWNLOAD and PATCH options by default. Used when generating a distribution
+# that includes the downloaded source files.
+#
+
+if [ ! -e source/ ]; then
+  echo "No 'source' directory to update"
+  exit 1
+fi
+
+cat >> source/presets.cmake << EOF
+set(DOWNLOAD FALSE CACHE BOOL "presets: Download repositories")
+set(PATCH FALSE CACHE BOOL "presets: Patch source after downloading")
+EOF
+


### PR DESCRIPTION
- Add support for an optional `source/presets.cmake` file that the cmake listfile will include if it exists. Used to disable the DOWNLOAD and PATCH options by default when generating a distribution that includes the downloaded source files.

- Update GitHub workflow to create presets file when generating the source tarball.

- Bump version number to 1.2.1.