### PR TITLE
Implement preconfig file

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -42,6 +42,9 @@ jobs:
           find . -name '.git*' -exec rm -fr {} +
           rm -fr build/
 
+      - name: Create preconfig file
+        run: ./scripts/preconfig.sh
+
       - name: Create tarballs
         run: |
           tar -czf /tmp/deps-source.tar.gz -C .. stratum-deps/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# generated files
-grpc.patch
-
 # build directories
 /build
 
@@ -8,7 +5,7 @@ grpc.patch
 /*deps*/
 /install
 
-# download directories
+# downloaded source
 source
 
 # editor directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Version 3.15 is the baseline for P4 Control Plane.
 cmake_minimum_required(VERSION 3.15)
 
-project(stratum-deps VERSION 1.2.0 LANGUAGES C CXX)
+project(stratum-deps VERSION 1.2.1 LANGUAGES C CXX)
 
 include(ExternalProject)
 include(CMakePrintHelpers)
@@ -22,6 +22,11 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.24 AND
 endif()
 
 cmake_print_variables(CMAKE_PROJECT_VERSION)
+
+# Include preconfig if file exists.
+if(EXISTS source/preconfig.cmake)
+  include(source/preconfig.cmake)
+endif()
 
 #-----------------------------------------------------------------------
 # Options

--- a/scripts/preconfig.sh
+++ b/scripts/preconfig.sh
@@ -1,0 +1,78 @@
+# Copyright 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Creates a cmake include file (source/preconfig.cmake) that disables the
+# DOWNLOAD and PATCH options by default. Used when generating a distribution
+# that includes the downloaded source files.
+#
+
+# Abort on error
+set -e
+
+##################
+# Default values #
+##################
+
+_DOWNLOAD=FALSE
+_PATCH=FALSE
+
+######################
+# Parse command line #
+######################
+
+SHORTOPTS=P:
+LONGOPTS=prefix:,download,no-download,patch,no-patch
+
+GETOPTS=$(getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@")
+eval set -- "${GETOPTS}"
+
+while true ; do
+  case "$1" in
+  --prefix|-P)
+    _PREFIX=$2
+    shift 2 ;;
+  --download)
+    _DOWNLOAD=TRUE
+    shift ;;
+  --no-download)
+    _DOWNLOAD=FALSE
+    shift ;;
+  --patch)
+    _PATCH=TRUE
+    shift ;;
+  --no-patch)
+    _PATCH=FALSE
+    shift ;;
+  --)
+    shift
+    break ;;
+  *)
+    echo "Invalid parameter: $1"
+    exit 1 ;;
+  esac
+done
+
+#########################
+# Create preconfig file #
+#########################
+
+if [ ! -e source/ ]; then
+  echo "No 'source' directory to update!"
+  exit 1
+fi
+
+if [ -e source/preconfig.cmake ]; then
+  echo "Removing existing preconfig.cmake file"
+fi
+
+cat >> source/preconfig.cmake << EOF
+set(DOWNLOAD ${_DOWNLOAD} CACHE BOOL "preconfig: Download repositories")
+set(PATCH ${_PATCH} CACHE BOOL "preconfig: Patch source after downloading")
+EOF
+
+if [ -n "${_PREFIX}" ]; then
+  _prefix=$(realpath ${_PREFIX})
+ cat >> source/preconfig.cmake << EOF
+set(CMAKE_INSTALL_PREFIX "${_prefix}" CACHE PATH "" FORCE)
+EOF
+fi

--- a/scripts/preconfig.sh
+++ b/scripts/preconfig.sh
@@ -21,16 +21,13 @@ _PATCH=FALSE
 ######################
 
 SHORTOPTS=P:
-LONGOPTS=prefix:,download,no-download,patch,no-patch
+LONGOPTS=download,no-download,patch,no-patch
 
 GETOPTS=$(getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@")
 eval set -- "${GETOPTS}"
 
 while true ; do
   case "$1" in
-  --prefix|-P)
-    _PREFIX=$2
-    shift 2 ;;
   --download)
     _DOWNLOAD=TRUE
     shift ;;
@@ -69,10 +66,3 @@ cat >> source/preconfig.cmake << EOF
 set(DOWNLOAD ${_DOWNLOAD} CACHE BOOL "preconfig: Download repositories")
 set(PATCH ${_PATCH} CACHE BOOL "preconfig: Patch source after downloading")
 EOF
-
-if [ -n "${_PREFIX}" ]; then
-  _prefix=$(realpath ${_PREFIX})
- cat >> source/preconfig.cmake << EOF
-set(CMAKE_INSTALL_PREFIX "${_prefix}" CACHE PATH "" FORCE)
-EOF
-fi


### PR DESCRIPTION
- Add support for an optional `source/preconfig.cmake` file that the cmake listfile will include if it exists. Used to disable the DOWNLOAD and PATCH options by default when creating a distribution that includes the downloaded source files.

- Implement `preconfig.sh` script to create `preconfig.cmake` file.

- Update GitHub workflow to create presets file when generating the source tarball.

- Bump version number to 1.2.1.