### PR TITLE
Improve gRPC patchfile handling

### DIFF
--- a/cmake/patches/grpc-current.patch.in
+++ b/cmake/patches/grpc-current.patch.in
@@ -1,0 +1,1 @@
+grpc-v1.59.2.patch.in

--- a/scripts/components.py
+++ b/scripts/components.py
@@ -71,6 +71,7 @@ def write_cmake_package(pkg, name, out):
     write_cmake_url(name, pkg, out)
     write_cmake_tag(name, pkg, out)
     write_cmake_version(name, pkg, out)
+    write_cmake_patchfile(name, pkg, out)
     write_cmake_defines(name, pkg, out)
     return
 
@@ -106,6 +107,12 @@ def write_cmake_version(name, pkg, out):
     version = optional(pkg, 'version')
     if version is not None:
         out.write('set({}_VERSION "{}")\n'.format(name, version))
+    return
+
+def write_cmake_patchfile(name, pkg, out):
+    version = optional(pkg, 'patchfile')
+    if version is not None:
+        out.write('set({}_PATCHFILE "{}")\n'.format(name, version))
     return
 
 def write_cmake_defines(name, pkg, out):


### PR DESCRIPTION
- Define a "patchfile" property in the components file. Update components.py to support it.

- Provide three ways to determine the gRPC patch file:

  - Explicitly specified by the `GRPC_PATCHFILE` cmake variable (per the "patchfile" component property). This allows the patch file to be independent of the gRPC version number.

  - Implicitly derived from the `GRPC_VERSION` cmake variable (per the "version" component property). This provides backward compatibility with the current mechanism.

  - Implicitly specified by a `grpc-current.patch.in` symlink in the `patches` folder. This allows an outside process to apply the patch without knowing the gRPC version.

- Refactor patchfile handling into two functions:

  - `define_grpc_patch_file()`, which selects the template file to use.
  - `define_grpc_patch_clause()`, which generates the patchfile from the template and defines the patch clause.

- Make the path to the patch file explicitly relative to the top-level directory (`CMAKE_SOURCE_DIR`) rather than implicitly relative to `grpc.cmake`. This mitigates the "patch file not found" error in the MEV build.

- If we are unable to apply to apply the gRPC patch, the worst outcome is that the RUNPATH of the gRPC plugins won't be updated, and the user will have to set LD_LIBRARY_PATH. This is (a) suboptimal rather than fatal, and (b) moot because this version of the Stratum dependencies breaks RPATH anyway. Make the messages WARNINGs rather than FATAL_ERRORs.

- Correct the version number in the header comment of the gRPC v1.59.2 patch file.