### PR TITLE
Remove paths-ignore filters from GitHub workflow

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -4,14 +4,8 @@ on:
   # Triggers the workflow on push or pull request events
   push:
     branches: [ "main" ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
   pull_request:
     branches: [ "main" ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
   # Allows the workflow to be run from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This keeps a documentation-only PR from being blocked, waiting for the required build check
to complete.