### PR TITLE
Update README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ required by Stratum.
 
 ## Project status
 
-The `stratum-deps` repository formally replaces the
+The `stratum-deps` repository replaces the
 [networking-recipe/setup](https://github.com/ipdk-io/networking-recipe/tree/main/setup)
-directory, which is being phased out.
+directory, which has been phased out.
 
-You can start using `stratum-deps` now. The most recent release is
-[version 1.2.1](https://github.com/ipdk-io/stratum-deps/releases/tag/v1.2.1).
+See the [Releases](https://github.com/ipdk-io/stratum-deps/releases) page
+for a list of releases, with their release notes and artifacts.
+The most recent release is
+[version 1.3.1](https://github.com/ipdk-io/stratum-deps/releases/tag/v1.3.1).
 
 See the [Transition Guide](/docs/transition-guide.md) for more information.
 
@@ -31,8 +33,3 @@ See the [Transition Guide](/docs/transition-guide.md) for more information.
 
 - [make-cross-deps.sh](/docs/make-cross-deps.rst)
 - [make-host-deps.sh](/docs/make-host-deps.rst)
-
-## Versions
-
-- See the [Releases](https://github.com/ipdk-io/stratum-deps/releases) page
-  for release notes and artifacts.


### PR DESCRIPTION
- Reworded _Project status_ to say that `networking-recipe/setup` has been phased out.
- Merged _Versions_ section into _Project status_.
- Changed most recent release to `1.3.1`.