### PR TITLE
Remove latest release number from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ directory, which has been phased out.
 
 See the [Releases](https://github.com/ipdk-io/stratum-deps/releases) page
 for a list of releases, with their release notes and artifacts.
-The most recent release is
-[version 1.3.1](https://github.com/ipdk-io/stratum-deps/releases/tag/v1.3.1).
 
 See the [Transition Guide](/docs/transition-guide.md) for more information.
 


### PR DESCRIPTION
- Including the latest release number in the README file means we have to update it every time we do a release. We've just referred the reader to the Releases page, which provides this information.