### PR TITLE
Made RE2 a discrete component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Version 3.15 is the baseline for P4 Control Plane.
 cmake_minimum_required(VERSION 3.15)
 
-project(stratum-deps VERSION 1.2.1 LANGUAGES C CXX)
+project(stratum-deps VERSION 1.3.0 LANGUAGES C CXX)
 
 include(ExternalProject)
 include(CMakePrintHelpers)
@@ -166,6 +166,7 @@ if(OVERRIDE_PKGS)
   include(cmake/zlib.cmake)
   include(cmake/c-ares.cmake)
   include(cmake/protobuf.cmake)
+  include(cmake/re2.cmake)
 endif()
 
 include(cmake/grpc.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Version 3.15 is the baseline for P4 Control Plane.
 cmake_minimum_required(VERSION 3.15)
 
-project(stratum-deps VERSION 1.3.0 LANGUAGES C CXX)
+project(stratum-deps VERSION 1.4.0 LANGUAGES C CXX)
 
 include(ExternalProject)
 include(CMakePrintHelpers)

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -36,5 +36,8 @@ set(PROTOBUF_GIT_TAG "6b5d8db01fe47478e8d400f550e797e6230d464e") # v25.0
 set(PROTOBUF_VERSION "25.0")
 set(PROTOBUF_ABSL_PROVIDER "package")
 
+set(RE2_GIT_URL "https://github.com/google/re2.git")
+set(RE2_GIT_TAG "0c5616df9c0aaa44c9440d87422012423d91c7d1") # 2022-04-01
+
 set(ZLIB_GIT_URL "https://github.com/madler/zlib")
 set(ZLIB_GIT_TAG "09155eaa2f9270dc4ed1fa13e2b4b2613e6e4851") # v1.3

--- a/cmake/grpc.cmake
+++ b/cmake/grpc.cmake
@@ -61,6 +61,7 @@ if(OVERRIDE_PKGS)
     -DgRPC_ABSL_PROVIDER=package
     -DgRPC_CARES_PROVIDER=package
     -DgRPC_PROTOBUF_PROVIDER=package
+    -DgRPC_RE2_PROVIDER=package
     -DgRPC_ZLIB_PROVIDER=package
   )
   set(_depends_clause
@@ -68,6 +69,7 @@ if(OVERRIDE_PKGS)
       abseil-cpp
       cares
       protobuf
+      re2
       zlib
   )
 endif()

--- a/cmake/re2.cmake
+++ b/cmake/re2.cmake
@@ -1,0 +1,29 @@
+# Downloads and builds re2
+#
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+GetDownloadClause(_download_clause ${RE2_GIT_URL} ${RE2_GIT_TAG})
+
+ExternalProject_Add(re2
+  ${_download_clause}
+
+  SOURCE_DIR
+    ${DEPS_SOURCE_DIR}/re2
+  CMAKE_ARGS
+    ${deps_BUILD_TYPE}
+    ${deps_TOOLCHAIN_FILE}
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+    -DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}
+    -DBUILD_SHARED_LIBS=ON
+    -DRE2_BUILD_TESTING=OFF
+  INSTALL_COMMAND
+    ${SUDO_CMD} ${CMAKE_MAKE_PROGRAM} install
+    ${LDCONFIG_CMD}
+)
+
+if(ON_DEMAND)
+  set_target_properties(re2 PROPERTIES EXCLUDE_FROM_ALL TRUE)
+endif()

--- a/components.json
+++ b/components.json
@@ -58,6 +58,12 @@
             "ABSL_PROVIDER": "package"
         }
     },
+    "re2": {
+        "name": "re2",
+        "url": "https://github.com/google/re2.git",
+        "sha": "0c5616df9c0aaa44c9440d87422012423d91c7d1",
+        "tag": "2022-04-01"
+    },
     "zlib": {
         "name": "zlib",
         "url": "https://github.com/madler/zlib",

--- a/scripts/prune.sh
+++ b/scripts/prune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2023 Intel Corporation
+# Copyright 2023-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 # Removes unnecessary third-party packages.
@@ -15,6 +15,7 @@ rm -fr ${SOURCE_DIR}/grpc/third_party/boringssl-with-bazel
 rm -fr ${SOURCE_DIR}/grpc/third_party/cares
 rm -fr ${SOURCE_DIR}/grpc/third_party/libuv
 rm -fr ${SOURCE_DIR}/grpc/third_party/protobuf
+rm -fr ${SOURCE_DIR}/grpc/third_party/re2
 rm -fr ${SOURCE_DIR}/grpc/third_party/zlib
 rm -fr ${SOURCE_DIR}/protobuf/third_party/abseil-cpp
 rm -fr ${SOURCE_DIR}/protobuf/third_party/benchmark


### PR DESCRIPTION
- Modified to download and build RE2 as a top-level component, overriding the copy bundled with gRPC.

- Bumped package version to 1.4.0.