### PR TITLE
Upgrade re2 to release 2022-12-01

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -37,7 +37,7 @@ set(PROTOBUF_VERSION "25.0")
 set(PROTOBUF_ABSL_PROVIDER "package")
 
 set(RE2_GIT_URL "https://github.com/google/re2.git")
-set(RE2_GIT_TAG "0c5616df9c0aaa44c9440d87422012423d91c7d1") # 2022-04-01
+set(RE2_GIT_TAG "4be240789d5b322df9f02b7e19c8651f3ccbf205") # 2022-12-01
 
 set(ZLIB_GIT_URL "https://github.com/madler/zlib")
 set(ZLIB_GIT_TAG "09155eaa2f9270dc4ed1fa13e2b4b2613e6e4851") # v1.3

--- a/components.json
+++ b/components.json
@@ -61,8 +61,8 @@
     "re2": {
         "name": "re2",
         "url": "https://github.com/google/re2.git",
-        "sha": "0c5616df9c0aaa44c9440d87422012423d91c7d1",
-        "tag": "2022-04-01"
+        "sha": "4be240789d5b322df9f02b7e19c8651f3ccbf205",
+        "tag": "2022-12-01"
     },
     "zlib": {
         "name": "zlib",


### PR DESCRIPTION
- Updated to a release that installs a pkg-config file.

The changes between 2022-04-01 and 2022-12-01 are: https://github.com/google/re2/compare/2022-04-01...2022-12-01
.