### PR TITLE
Pin workflow scripts to Ubuntu-22.04

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -23,11 +23,11 @@ env:
   DEPS_SRC_ARTIFACT: deps-source
   DEPS_SRC_TARBALL: deps-source.tar.gz
   DEPS_BIN_ARTIFACT: deps-binary
-  DEPS_BIN_TARBALL: deps-ubuntu-latest-x86_64.tar.gz
+  DEPS_BIN_TARBALL: deps-ubuntu-22.04-x86_64.tar.gz
 
 jobs:
   build_stratum_deps:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       # Check out repository under $GITHUB_WORKSPACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Version 3.15 is the baseline for P4 Control Plane.
 cmake_minimum_required(VERSION 3.15)
 
-project(stratum-deps VERSION 1.4.0 LANGUAGES C CXX)
+project(stratum-deps VERSION 1.3.4 LANGUAGES C CXX)
 
 include(ExternalProject)
 include(CMakePrintHelpers)


### PR DESCRIPTION
- Changed `ubuntu-latest` to `ubuntu-22.04` in the pipeline, in preparation for GitHub bumping ubuntu-latest to 24.04.

This change is in response to the following warning from GitHub Actions:
```text
ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636
```