### PR TITLE
Remove unnneeded re2 check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,19 +182,6 @@ include(cmake/json.cmake)
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
 
-# find_package(re2) does not work on apt install in Ubuntu
-# (used in github workflow)
-find_path(RE2_INCLUDE_DIR re2/re2.h)
-find_library(RE2_LIBRARY re2)
-if(RE2_INCLUDE_DIR AND RE2_LIBRARY)
-  set_target_properties(re2::re2 PROPERTIES
-    IMPORTED_LOCATION "${RE2_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${RE2_INCLUDE_DIR}"
-  )
-else()
-  message(FATAL_ERROR "RE2 library not found")
-endif()
-
 # Print configuration summary
 include(FeatureSummary)
 feature_summary(WHAT ALL)


### PR DESCRIPTION
The re2 check added was relying on the OS insalled re2 instead of building it from source. We want to use the source built version, which allows us to control the versions as needed.

Removing this section from top-level CMakeLists file